### PR TITLE
NWC: use the lud16 from the NWC URL as the receive code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Unreleased**
+- NWC: use the Lightning Address from the NWC URL's `lud16` parameter as the receive code, so an NWC-only piggy shows a receive QR without also having to fill in the static receive code manually (coinos and LNBits' nwcprovider include it in generated URLs)
+- NWC: prefix the receive QR with the `lightning:` URI scheme so phone cameras and wallet scanners open a Lightning-enabled app instead of treating it as plain text
+
 **6.3.0**
 - Update Adafruit BusIO from 1.15.0 to 1.17.0
 - Update Adafruit GFX Library from 1.11.9 to 1.12.0

--- a/Main/LNBits.ino
+++ b/Main/LNBits.ino
@@ -80,7 +80,19 @@ String getLNURLp() {
   if (cachedLNURLp.length() > 0) return cachedLNURLp;
 
   if (walletToUse() != WALLET_LNBITS) {
-    Serial.println("WARNING: No receive code is configured and it can only be fetched for LNBits");
+    // NWC URLs can carry the wallet's Lightning Address as a lud16 query
+    // parameter (coinos, LNBits nwcprovider since PR #27, ...). Use it so
+    // an NWC-only piggy shows a receive QR without the user also having
+    // to fill in the static receive code manually.
+    if (walletToUse() == WALLET_NWC) {
+      String lud16 = getLud16FromNWCURL();
+      if (lud16.length() > 0) {
+        Serial.println("Using lud16 from the NWC URL as receive code: " + lud16);
+        cachedLNURLp = lud16;
+        return lud16;
+      }
+    }
+    Serial.println("WARNING: No receive code is configured; it can only be fetched from LNBits or taken from the NWC URL's lud16 parameter");
     return "";
   }
 

--- a/Main/NWC.ino
+++ b/Main/NWC.ino
@@ -160,3 +160,72 @@ void fetchNWCPayments(int max_payments) {
   maxtime = 0; // start from the "now" and go backwards
   requestedTime = NOT_SPECIFIED;
 }
+
+// ---------------------------------------------------------------------------
+// lud16 extraction from the NWC URL.
+//
+// NWC URLs can carry the wallet's Lightning Address as a `lud16` query
+// parameter (e.g. coinos, and LNBits' nwcprovider since PR #27):
+//   nostr+walletconnect://<pubkey>?relay=...&secret=...&lud16=user@host
+// Using it means an NWC-only piggy gets a receive QR with zero extra
+// configuration, instead of showing nothing until the user manually
+// fills in the static receive code.
+// ---------------------------------------------------------------------------
+
+static int nwcHexNibble(char h) {
+  if (h >= '0' && h <= '9') return h - '0';
+  if (h >= 'a' && h <= 'f') return h - 'a' + 10;
+  if (h >= 'A' && h <= 'F') return h - 'A' + 10;
+  return -1;
+}
+
+// Minimal percent-decoder. Some NWC generators URL-encode parameter
+// values (e.g. the @ in the lud16 as %40, or the relay's :// as
+// %3A%2F%2F); others emit them raw. Handles both.
+String nwcURLDecode(const String &in) {
+  String out;
+  out.reserve(in.length());
+  for (unsigned int i = 0; i < in.length(); i++) {
+    char c = in[i];
+    if (c == '%' && i + 2 < in.length()) {
+      int hi = nwcHexNibble(in[i + 1]);
+      int lo = nwcHexNibble(in[i + 2]);
+      if (hi >= 0 && lo >= 0) {
+        out += (char)(hi * 16 + lo);
+        i += 2;
+        continue;
+      }
+    }
+    out += c;
+  }
+  return out;
+}
+
+// Return the (percent-decoded) value of `param` from the NWC URL's query
+// string, or "" if absent / no NWC URL configured.
+String getNWCURLParam(const String &param) {
+  if (!isConfigured(nwcURL)) return "";
+  String url = String(nwcURL);
+  int queryStart = url.indexOf('?');
+  if (queryStart < 0) return "";
+  String query = url.substring(queryStart + 1);
+  unsigned int pos = 0;
+  while (pos < query.length()) {
+    int amp = query.indexOf('&', pos);
+    if (amp < 0) amp = query.length();
+    int eq = query.indexOf('=', pos);
+    if (eq > (int)pos && eq < amp) {
+      if (query.substring(pos, eq) == param) {
+        return nwcURLDecode(query.substring(eq + 1, amp));
+      }
+    }
+    pos = amp + 1;
+  }
+  return "";
+}
+
+// The wallet's Lightning Address from the NWC URL's lud16 parameter,
+// or "" if it doesn't carry one.
+String getLud16FromNWCURL() {
+  return getNWCURLParam("lud16");
+}

--- a/Main/NWC.ino
+++ b/Main/NWC.ino
@@ -225,7 +225,19 @@ String getNWCURLParam(const String &param) {
 }
 
 // The wallet's Lightning Address from the NWC URL's lud16 parameter,
-// or "" if it doesn't carry one.
+// prefixed with the lightning: URI scheme, or "" if the URL doesn't
+// carry one.
+//
+// The prefix matters for the receive QR: phone cameras and wallet
+// scanners dispatch lightning:-scheme QRs straight into a Lightning-
+// enabled app, whereas a bare user@host scans as plain text on many
+// of them. Idempotent in case a generator ever includes the scheme
+// in the parameter itself.
 String getLud16FromNWCURL() {
-  return getNWCURLParam("lud16");
+  String lud16 = getNWCURLParam("lud16");
+  if (lud16.length() == 0) return lud16;
+  String lower = lud16;
+  lower.toLowerCase();
+  if (lower.startsWith("lightning:")) return lud16;
+  return "lightning:" + lud16;
 }


### PR DESCRIPTION
## Summary

When a user pastes an NWC connection string that carries the wallet's Lightning Address as a `lud16` query parameter — coinos does this, and LNBits' nwcprovider does since its PR #27 —

```
nostr+walletconnect://<pubkey>?relay=...&secret=...&lud16=user@host
```

the firmware never used it. `getLNURLp()` returns the manually configured static receive code, or fetches the first LNURLp link **for LNBits only**; for NWC it warned `No receive code is configured and it can only be fetched for LNBits` and returned `""`. So an NWC-only piggy showed **no receive QR at all**, unless the user also typed their Lightning Address into the static receive code field — even though it was right there in the URL they pasted.

## Fix

* **`NWC.ino`**: new `getLud16FromNWCURL()` — a small query-param extractor with a minimal percent-decoder. Generators vary: coinos emits the lud16 raw, others URL-encode the `@` as `%40` (and the relay param is typically `%3A%2F%2F`-encoded), so decoding is applied per-value.
* **`LNBits.ino` `getLNURLp()`**: falls back to the lud16 for `WALLET_NWC` before giving up, caching the result the same way the LNBits path does. A manually configured static receive code still wins when set.

## Verified end-to-end in the QEMU emulator

Using the Emulation.md setup (WiFi-patched QEMU) with a **real coinos NWC connection**: the piggy joins the emulated "Open Wifi", talks NIP-47 over `wss://relay.coinos.io`, fetches the live balance, and now renders the receive QR for the lud16.

Serial, before → after:

```
WARNING: No receive code is configured and it can only be fetched for LNBits
INFO: not showing LNURLp QR code because no LNURLp code was found.
```
```
Using lud16 from the NWC URL as receive code: bffpiggy@coinos.io
Building LNURLp QR code...
qrVersion = 2 and pixSize = 2
```

And the emulated ePaper shows balance + transactions + the QR in the top-right corner where there previously was empty space.

## Notes

* The QR encodes `lightning:user@host` (second commit): phone cameras and wallet scanners dispatch `lightning:`-scheme QRs straight into a Lightning-enabled app, whereas a bare lud16 scans as plain text on many of them. Same convention as the MicroPythonOS app's `ensure_lightning_prefix()`. Idempotent if a generator ever includes the scheme in the parameter itself. Verified in the emulator — the QR still fits version 2.
* No behaviour change for LNBits wallets or for users who set the static receive code manually.
