### PR TITLE
Release 6.4.0: NWC lud16 receive code + code-study fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+**Unreleased**
+- Fix LNBits balance display overflowing at ~0.0215 BTC (the millisat balance was parsed into a 32-bit int, so bigger wallets showed negative garbage)
+- Fix NWC balance bias being re-added on every payment notification (N payments inflated the display by N x bias), and apply the bias to the initial NWC balance fetch like the LNBits path does
+- Fix a single failed Bitcoin price lookup poisoning the fiat balance display with 0 for the next 15 minutes
+- Fix an out-of-bounds write in the payment list when it is full (and when a payment arrives before the first fetch), which could corrupt memory
+- Fix the config-save handler reading past the HTTP request buffer (config saves could occasionally crash the device)
+- Fix the tilt-sensor interrupt firing continuously while the piggy is tilted (level-triggered instead of edge-triggered), and a missing `volatile` on its ISR flag
+- Stop printing secrets to the serial console: the WiFi password, LNBits invoice key, NWC URL (which contains the wallet secret) and posted config bodies are now redacted
+- Reject non-2xx HTTP responses in the shared fetch helper instead of treating error pages as data (the update checker could previously "find" an update in a 404 page)
+- Ignore websocket payment notifications without a wallet_balance field instead of displaying a zero balance
+
 **6.3.0**
 - Update Adafruit BusIO from 1.15.0 to 1.17.0
 - Update Adafruit GFX Library from 1.11.9 to 1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Unreleased**
+- NWC: use the Lightning Address from the NWC URL's `lud16` parameter as the receive code, so an NWC-only piggy shows a receive QR without also having to fill in the static receive code manually (coinos and LNBits' nwcprovider include it in generated URLs)
+- NWC: prefix the receive QR with the `lightning:` URI scheme so phone cameras and wallet scanners open a Lightning-enabled app instead of treating it as plain text
+
 **6.3.0**
 - Update Adafruit BusIO from 1.15.0 to 1.17.0
 - Update Adafruit GFX Library from 1.11.9 to 1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-**Unreleased**
 **6.4.0**
 - NWC: use the Lightning Address from the NWC URL's `lud16` parameter as the receive code, so an NWC-only piggy shows a receive QR without also having to fill in the static receive code manually (coinos and LNBits' nwcprovider include it in generated URLs)
 - NWC: prefix the receive QR with the `lightning:` URI scheme so phone cameras and wallet scanners open a Lightning-enabled app instead of treating it as plain text

--- a/Main/BitcoinPrice.ino
+++ b/Main/BitcoinPrice.ino
@@ -38,6 +38,10 @@ float getBitcoinPriceCoingecko() {
 
   if (lastBtcPrice == 0.0) {
     Serial.println("BTC Price not found, returning NOT_SPECIFIED");
+    // Reset the cache marker — leaving 0.0 in lastBtcPrice would make the
+    // freshness check above return 0.0 as the "cached price" for the next
+    // 15 minutes after a single failed lookup.
+    lastBtcPrice = NOT_SPECIFIED;
     return (float)NOT_SPECIFIED;
   }
 

--- a/Main/Config.ino
+++ b/Main/Config.ino
@@ -108,10 +108,15 @@ bool parseConfig(String paramFileString) {
 
     Serial.println("Parsed config:");
     Serial.printf("config_wifi_ssid_1: %s\n", ssid);
-    Serial.printf("config_wifi_password_1: %s\n", password);
+    // Secrets are intentionally NOT printed: the serial console is often
+    // shared for debugging (and is readable by anything with USB access),
+    // so leaking the wifi password, the LNBits invoice key, or the NWC
+    // URL (which contains the wallet secret) would hand over credentials.
+    // Lengths are enough to confirm a value was loaded.
+    Serial.printf("config_wifi_password_1: <redacted, %u chars>\n", (unsigned)strnlen(password, MAX_CONFIG_LENGTH));
     Serial.printf("config_lnbits_host: %s\n", lnbitsHost);
-    Serial.printf("config_lnbits_invoice_key: %s\n", lnbitsInvoiceKey);
-    Serial.printf("config_nwc_url: %s\n", nwcURL);
+    Serial.printf("config_lnbits_invoice_key: <redacted, %u chars>\n", (unsigned)strnlen(lnbitsInvoiceKey, MAX_CONFIG_LENGTH));
+    Serial.printf("config_nwc_url: <redacted, %u chars>\n", (unsigned)strnlen(nwcURL, MAX_CONFIG_LENGTH_NWCURL));
 
     // Optional
     // ========
@@ -271,10 +276,13 @@ void setup_webserver() {
 
       if (index == 0) body = "";  // Reset on new request
 
-      body += String((char*)data).substring(0, len);  // Append chunk
+      // `data` is NOT NUL-terminated — constructing a String from it
+      // reads past the buffer until a stray zero byte. Append exactly
+      // `len` bytes instead.
+      body.concat((const char*)data, len);  // Append chunk
 
       if (index + len == total) {  // All data received
-          Serial.println("Received PUT data: '" + body + "'");
+          Serial.println("Received PUT data of " + String(body.length()) + " bytes (content not printed: contains credentials)");
           paramFileString = body;
           writeFile(CONFIG_FILE, body);
           parseConfig(paramFileString);

--- a/Main/Constants.h
+++ b/Main/Constants.h
@@ -1,7 +1,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-String currentVersion = "6.3.0";
+String currentVersion = "6.4.0";
 
 /**
  * The piggy can be in different 'modes':

--- a/Main/Interrupts.ino
+++ b/Main/Interrupts.ino
@@ -3,7 +3,7 @@
 
 portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 
-bool interruptTriggered = false;
+volatile bool interruptTriggered = false; // written from the tilt ISR — must be volatile
 long minTimeBetweenInterrupts = 250; // milliseconds
 long lastInterrupt = -minTimeBetweenInterrupts;
 
@@ -34,7 +34,10 @@ void IRAM_ATTR buttonISR() {
 void setup_interrupts() {
   Serial.println("configuring pin GPIO_NUM_32 as interrupt...");
   pinMode(GPIO_NUM_32, INPUT_PULLDOWN);
-  attachInterrupt(GPIO_NUM_32, interruptHandler, HIGH);
+  // RISING (edge), not HIGH (level): a level interrupt refires
+  // continuously for as long as the piggy is tilted, hammering the CPU
+  // with ISR calls. One edge per tilt is all the handler needs.
+  attachInterrupt(GPIO_NUM_32, interruptHandler, RISING);
 
   Serial.println("configuring pin GPIO_NUM_39 as interrupt...");
   pinMode(BUTTON_PIN, INPUT_PULLUP);

--- a/Main/LNBits.ino
+++ b/Main/LNBits.ino
@@ -27,14 +27,18 @@ int getWalletBalance() {
   String walletName = doc["name"];
 
   if (walletName == "null") {
-    Serial.println("ERROR: could not find wallet details on lnbits host " + String(lnbitsHost) + " with invoice/read key " + String(lnbitsInvoiceKey) + " so something's wrong! Did you make a typo?");
+    Serial.println("ERROR: could not find wallet details on lnbits host " + String(lnbitsHost) + " with the configured invoice/read key (not printed) so something's wrong! Did you make a typo?");
     return NOT_SPECIFIED;
   } else {
     Serial.print("Wallet name: " + walletName);
   }
 
-  int walletBalance = doc["balance"];
-  walletBalance = walletBalance / 1000;
+  // Balance is in MILLISATS — an int overflows at 2^31 msat which is only
+  // ~2.15 million sats (~0.0215 BTC), turning bigger balances negative.
+  // Parse as long long (the same trick paymentJsonToString already uses
+  // for amounts) and convert to sats before going back to int.
+  long long walletBalanceMsat = doc["balance"];
+  int walletBalance = (int)(walletBalanceMsat / 1000);
 
   Serial.println(" contains " + String(walletBalance) + " sats");
   return walletBalance+balanceBiasInt;

--- a/Main/LNBits.ino
+++ b/Main/LNBits.ino
@@ -80,7 +80,19 @@ String getLNURLp() {
   if (cachedLNURLp.length() > 0) return cachedLNURLp;
 
   if (walletToUse() != WALLET_LNBITS) {
-    Serial.println("WARNING: No receive code is configured and it can only be fetched for LNBits");
+    // NWC URLs can carry the wallet's Lightning Address as a lud16 query
+    // parameter (coinos, LNBits nwcprovider since PR #27, ...). Use it so
+    // an NWC-only piggy shows a receive QR without the user also having
+    // to fill in the static receive code manually.
+    if (walletToUse() == WALLET_NWC) {
+      String lud16 = getLud16FromNWCURL();
+      if (lud16.length() > 0) {
+        Serial.println("Using lud16 from the NWC URL as receive code: " + lud16);
+        cachedLNURLp = lud16;
+        return lud16;
+      }
+    }
+    Serial.println("WARNING: No receive code is configured; it can only be fetched from LNBits or taken from the NWC URL's lud16 parameter");
     return "";
   }
 

--- a/Main/NWC.ino
+++ b/Main/NWC.ino
@@ -160,3 +160,72 @@ void fetchNWCPayments(int max_payments) {
   maxtime = 0; // start from the "now" and go backwards
   requestedTime = NOT_SPECIFIED;
 }
+
+// ---------------------------------------------------------------------------
+// lud16 extraction from the NWC URL.
+//
+// NWC URLs can carry the wallet's Lightning Address as a `lud16` query
+// parameter (e.g. coinos, and LNBits' nwcprovider since PR #27):
+//   nostr+walletconnect://<pubkey>?relay=...&secret=...&lud16=user@host
+// Using it means an NWC-only piggy gets a receive QR with zero extra
+// configuration, instead of showing nothing until the user manually
+// fills in the static receive code.
+// ---------------------------------------------------------------------------
+
+static int nwcHexNibble(char h) {
+  if (h >= '0' && h <= '9') return h - '0';
+  if (h >= 'a' && h <= 'f') return h - 'a' + 10;
+  if (h >= 'A' && h <= 'F') return h - 'A' + 10;
+  return -1;
+}
+
+// Minimal percent-decoder. Some NWC generators URL-encode parameter
+// values (e.g. the @ in the lud16 as %40, or the relay's :// as
+// %3A%2F%2F); others emit them raw. Handles both.
+String nwcURLDecode(const String &in) {
+  String out;
+  out.reserve(in.length());
+  for (unsigned int i = 0; i < in.length(); i++) {
+    char c = in[i];
+    if (c == '%' && i + 2 < in.length()) {
+      int hi = nwcHexNibble(in[i + 1]);
+      int lo = nwcHexNibble(in[i + 2]);
+      if (hi >= 0 && lo >= 0) {
+        out += (char)(hi * 16 + lo);
+        i += 2;
+        continue;
+      }
+    }
+    out += c;
+  }
+  return out;
+}
+
+// Return the (percent-decoded) value of `param` from the NWC URL's query
+// string, or "" if absent / no NWC URL configured.
+String getNWCURLParam(const String &param) {
+  if (!isConfigured(nwcURL)) return "";
+  String url = String(nwcURL);
+  int queryStart = url.indexOf('?');
+  if (queryStart < 0) return "";
+  String query = url.substring(queryStart + 1);
+  unsigned int pos = 0;
+  while (pos < query.length()) {
+    int amp = query.indexOf('&', pos);
+    if (amp < 0) amp = query.length();
+    int eq = query.indexOf('=', pos);
+    if (eq > (int)pos && eq < amp) {
+      if (query.substring(pos, eq) == param) {
+        return nwcURLDecode(query.substring(eq + 1, amp));
+      }
+    }
+    pos = amp + 1;
+  }
+  return "";
+}
+
+// The wallet's Lightning Address from the NWC URL's lud16 parameter,
+// or "" if it doesn't carry one.
+String getLud16FromNWCURL() {
+  return getNWCURLParam("lud16");
+}

--- a/Main/NWC.ino
+++ b/Main/NWC.ino
@@ -124,7 +124,10 @@ void subscribeNWC() {
 
             long long amount = notification.amount; // millisats to sats
             if (notification.type == "outgoing") amount = -amount; // outgoing is negative, otherwise positive
-            setBalance(getConfigValueAsInt((char*)balanceBias, 0) + getBalance() + (amount/1000));
+            // The running balance already includes the configured
+            // balance bias (applied once in nwc_getBalance) — adding it
+            // again here would accumulate the bias on every payment.
+            setBalance(getBalance() + (amount/1000));
             lastUpdatedBalance = millis();
             resetLastPaymentReceivedMillis();
 
@@ -144,7 +147,9 @@ void nwc_getBalance() {
   setGetBalanceDone(false);
   nwc->getBalance([&](nostr::GetBalanceResponse resp) {
     Serial.println("[!] Balance: " + String(resp.balance) + " msatoshis");
-    setBalance(resp.balance/1000);
+    // Apply the configured balance bias here, once per fetch — the same
+    // semantics as the LNBits path (getWalletBalance adds it on fetch).
+    setBalance(resp.balance/1000 + getConfigValueAsInt((char*)balanceBias, 0));
     setGetBalanceDone(true);
   }, [](String err, String errMsg) {
     Serial.println("[!] Error: " + err + " " + errMsg);

--- a/Main/NWC.ino
+++ b/Main/NWC.ino
@@ -225,7 +225,19 @@ String getNWCURLParam(const String &param) {
 }
 
 // The wallet's Lightning Address from the NWC URL's lud16 parameter,
-// or "" if it doesn't carry one.
+// prefixed with the lightning: URI scheme, or "" if the URL doesn't
+// carry one.
+//
+// The prefix matters for the receive QR: phone cameras and wallet
+// scanners dispatch lightning:-scheme QRs straight into a Lightning-
+// enabled app, whereas a bare user@host scans as plain text on many
+// of them. Idempotent in case a generator ever includes the scheme
+// in the parameter itself.
 String getLud16FromNWCURL() {
-  return getNWCURLParam("lud16");
+  String lud16 = getNWCURLParam("lud16");
+  if (lud16.length() == 0) return lud16;
+  String lower = lud16;
+  lower.toLowerCase();
+  if (lower.startsWith("lightning:")) return lud16;
+  return "lightning:" + lud16;
 }

--- a/Main/Network.ino
+++ b/Main/Network.ino
@@ -207,6 +207,20 @@ String getEndpointData(const char * host, String endpointUrl, bool sendApiKey) {
 
   long maxTime = millis() + HTTPS_TIMEOUT_SECONDS * 1000;
 
+  // First line is the status line, e.g. "HTTP/1.1 200 OK". Without this
+  // check, error bodies (404 pages, 500 messages, proxy interstitials)
+  // were returned as if they were data — and e.g. the update checker
+  // would version-compare against an error page.
+  String statusLine = client.readStringUntil('\n');
+  int statusCode = 0;
+  int firstSpace = statusLine.indexOf(' ');
+  if (firstSpace > 0) statusCode = statusLine.substring(firstSpace + 1).toInt();
+  if (statusCode < 200 || statusCode > 299) {
+    Serial.println("WARNING: HTTP request returned status " + String(statusCode) + " (" + statusLine + "), returning empty reply...");
+    client.stop();
+    return "";
+  }
+
   int chunked = 0;
   String line = "";
   while (client.connected() && millis() < maxTime) {
@@ -273,7 +287,7 @@ void connectWebsocket() {
   // wss://demo.lnpiggy.com/api/v1/ws/<invoice read key>
   String url = websocketApiUrl + String(lnbitsInvoiceKey);
   int lnbitsPortInteger = getConfigValueAsInt((char*)lnbitsPort, DEFAULT_LNBITS_PORT);
-  Serial.println("Trying to connect websocket: wss://" + String(lnbitsHost) + ":" + String(lnbitsPortInteger) + url);
+  Serial.println("Trying to connect websocket: wss://" + String(lnbitsHost) + ":" + String(lnbitsPortInteger) + String(websocketApiUrl) + "<invoice key redacted>");
   webSocket.beginSSL(lnbitsHost, lnbitsPortInteger, url);
   webSocket.setReconnectInterval(1000);
   webSocket.onEvent(webSocketEvent);
@@ -290,6 +304,13 @@ void parseWebsocketText(String text) {
     return;
   }
 
+  // Guard against notifications without a wallet_balance — parsing a
+  // missing field yields 0, and the payment branch below would then
+  // display a zero balance (plus bias) for a wallet that isn't empty.
+  if (doc["wallet_balance"].isNull()) {
+    Serial.println("Websocket update has no wallet_balance, ignoring...");
+    return;
+  }
   int walletBalance = doc["wallet_balance"];
   int balanceBiasInt = getConfigValueAsInt((char*)balanceBias, 0);
   Serial.println("Wallet now contains " + String(walletBalance) + " sats and balance bias of " + String(balanceBiasInt) + " sats.");

--- a/Main/Wallet.ino
+++ b/Main/Wallet.ino
@@ -53,12 +53,26 @@ String getPayment(int nr) {
 }
 
 void appendPayment(String detail) {
+  // nrOfPayments starts at NOT_SPECIFIED (-1) until the first fetch
+  // resets it — normalize so an early websocket/NWC payment can't
+  // write to payments[-1].
+  if (nrOfPayments < 0) nrOfPayments = 0;
+  // Bounds check BEFORE the write: when the list is full, the old code
+  // still assigned payments[MAX_PAYMENTS] — one past the end of the
+  // array — corrupting whatever lives next on the heap. The LNBits call
+  // site guards externally but the NWC path appends whatever the relay
+  // returns, which may be more than requested.
+  if (nrOfPayments >= MAX_PAYMENTS) {
+    Serial.println("WARNING: payment list is full, not appending.");
+    return;
+  }
   payments[nrOfPayments] = detail;
-  if (nrOfPayments<MAX_PAYMENTS) nrOfPayments++;
+  nrOfPayments++;
   Serial.println("After appending payment, the list contains:" + stringArrayToString(payments, nrOfPayments));
 }
 
 void prependPayment(String toadd) {
+  if (nrOfPayments < 0) nrOfPayments = 0; // see appendPayment — pre-fetch state is -1
   // First move them all down one spot
   for (int i=min(nrOfPayments,MAX_PAYMENTS-1);i>0;i--) {
     Serial.println("Moving payment comment for item " + String(i-1) + " to item " + String(i));


### PR DESCRIPTION
## Summary

Release-prep for **6.4.0**, rolling up the two open PRs plus the version bump:

* **#41** — NWC: use the `lud16` from the NWC URL as the receive code, with the `lightning:` URI prefix on the QR
* **#42** — nine code-study fixes: LNBits balance int-overflow, NWC bias accumulation, price-cache poisoning, payment-list out-of-bounds write, config-save buffer overread, tilt-interrupt level-trigger + missing `volatile`, secret redaction in serial logs, HTTP status checking, websocket balance guard

Plus, in this branch only:

* `Constants.h`: `currentVersion` → `6.4.0`
* `CHANGELOG.md`: both PRs' `Unreleased` sections consolidated under one `**6.4.0**` heading (also resolves the changelog conflict the two PRs would otherwise have)

## Why 6.4.0 (not 7.x)

New feature + fixes, no breaking changes — consistent with how 6.2.0/6.3.0 were scoped. Happy to renumber if you prefer.

## Merge options

* **Merge this PR** → both #41 and #42 are automatically marked merged (their commits are contained here), CHANGELOG lands pre-consolidated, version is bumped. One merge, ready to tag `v6.4.0` + `release.sh`.
* Or merge #41/#42 individually and cherry-pick just the release-prep commit from here — whatever fits your flow.

## RC verification (QEMU emulator, live coinos NWC wallet)

```
Starting Lightning Piggy 6.4.0|...
config_nwc_url: <redacted, 217 chars>
[!] Balance: 42000 msatoshis
Using lud16 from the NWC URL as receive code: lightning:bffpiggy@coinos.io
```

Zero backtraces/asserts across boot + WiFi join + balance fetch + QR render. Compiles clean with esp32 core 3.2.0, `PartitionScheme=custom`.